### PR TITLE
residuals: change `glance` to `augment`

### DIFF
--- a/07-regression-web.Rmd
+++ b/07-regression-web.Rmd
@@ -653,7 +653,7 @@ Then use `tidy`, `augment`, and `glance` respectively on the output. Assign the 
 
 ##### Exercise 16(d) {-}
 
-Use the `glance` output from above to create a residual plot with a blue horizontal reference line.
+Use the `augment` output from above to create a residual plot with a blue horizontal reference line.
 
 ::: {.answer}
 


### PR DESCRIPTION
Since residuals come from the results of `augment` rather than of `glance`, the directions for producing residuals plots should refer to `augment`.
(I'm sending a second pull request for the downloadable rmd because I can't figure out how to rebase on github web, lol.)