### PR TITLE
residuals: change `glance` to `augment`

### DIFF
--- a/docs/chapter_downloads/07-regression.Rmd
+++ b/docs/chapter_downloads/07-regression.Rmd
@@ -661,7 +661,7 @@ Then use `tidy`, `augment`, and `glance` respectively on the output. Assign the 
 
 ##### Exercise 16(d)
 
-Use the `glance` output from above to create a residual plot with a blue horizontal reference line.
+Use the `augment` output from above to create a residual plot with a blue horizontal reference line.
 
 ::: {.answer}
 


### PR DESCRIPTION
Since residuals come from the results of `augment` rather than of `glance`, the directions for producing residuals plots should refer to `augment`.
(Here's the second of two very same edits on two very related files.)