### PR TITLE
module 9: `slice` rationale

### DIFF
--- a/09-intro_to_randomization_2-web.Rmd
+++ b/09-intro_to_randomization_2-web.Rmd
@@ -183,7 +183,9 @@ decision_sex_diff <- decision_sex_tabyl %>%
 decision_sex_diff
 ```
 
-We don't really need both the positive and negative values. Let's just keep the first row and keep track of which direction we subtracted to get it. (The positive difference results from the male promotion rate minus the female promotion rate.) We can use `slice` to grab the first row:
+Notice the order of subtraction: we're doing the men's rates minus the women's rates.
+
+This computes both the difference in promotion rates (in the first row) and the difference in not-promoted rates (in the second row). Let's just keep the first row, since we care more about promotion rates. (That's our success category.) We can use `slice` to grab the first row:
 
 ```{r}
 decision_sex_diff %>%

--- a/docs/chapter_downloads/09-intro_to_randomization_2.Rmd
+++ b/docs/chapter_downloads/09-intro_to_randomization_2.Rmd
@@ -191,7 +191,9 @@ decision_sex_diff <- decision_sex_tabyl %>%
 decision_sex_diff
 ```
 
-We don't really need both the positive and negative values. Let's just keep the first row and keep track of which direction we subtracted to get it. (The positive difference results from the male promotion rate minus the female promotion rate.) We can use `slice` to grab the first row:
+Notice the order of subtraction: we're doing the men's rates minus the women's rates.
+
+This computes both the difference in promotion rates (in the first row) and the difference in not-promoted rates (in the second row). Let's just keep the first row, since we care more about promotion rates. (That's our success category.) We can use `slice` to grab the first row:
 
 ```{r}
 decision_sex_diff %>%


### PR DESCRIPTION
The old description for why we're using slice made me confuse myself -- it made it sound like one row would be "men - women" and the other would be "women - men."

It's actually that we're finding $\hat{p}_\text{men, promoted} - \hat{p}_\text{women, promoted}$ in the first row, and $\hat{p}_\text{men, not promoted} - \hat{p}_\text{women, not promoted}$ in the second row. That is, the order of the subtraction doesn't change, we're just looking at the second row of the contingency table.

Then it made more sense in my brain why we should slice out the first row and discard the second (we don't care about not-promotion rates).