### PR TITLE
module 7: focus "your turn" on `fl_bm` model

### DIFF
--- a/07-regression-web.Rmd
+++ b/07-regression-web.Rmd
@@ -719,7 +719,7 @@ Please write up your answer here.
 
 ##### Exercise 16(j) {-}
 
-Use the equation of the regression line to predict the FAIR policy rate per 100 housing units for a ZIP code with 80% racial minorities. Show your work. Then put that prediction into a full, contextually meaningful sentence.
+Use the equation of the regression line to predict the flipper length of a penguin with body mass 4200 grams. Show your work. Then put that prediction into a full, contextually meaningful sentence.
 
 ::: {.answer}
 
@@ -730,7 +730,7 @@ Please write up your answer here.
 
 ##### Exercise 16(k) {-}
 
-Using the value of $R^2$ from the `glance` output, write a full, contextually meaningful sentence interpreting that value.
+Using the value of $R^2$ from the `glance` output for the model of flipper length by body mass, write a full, contextually meaningful sentence interpreting that value.
 
 ::: {.answer}
 

--- a/docs/chapter_downloads/07-regression.Rmd
+++ b/docs/chapter_downloads/07-regression.Rmd
@@ -727,7 +727,7 @@ Please write up your answer here.
 
 ##### Exercise 16(j)
 
-Use the equation of the regression line to predict the FAIR policy rate per 100 housing units for a ZIP code with 80% racial minorities. Show your work. Then put that prediction into a full, contextually meaningful sentence.
+Use the equation of the regression line to predict the flipper length of a penguin with body mass 4200 grams. Show your work. Then put that prediction into a full, contextually meaningful sentence.
 
 ::: {.answer}
 
@@ -738,7 +738,7 @@ Please write up your answer here.
 
 ##### Exercise 16(k)
 
-Using the value of $R^2$ from the `glance` output, write a full, contextually meaningful sentence interpreting that value.
+Using the value of $R^2$ from the `glance` output for the model of flipper length by body mass, write a full, contextually meaningful sentence interpreting that value.
 
 ::: {.answer}
 


### PR DESCRIPTION
- Most of Exercise 16 focuses on a linear model of flipper length ~ body mass from the penguins data set. However, 16(j) jumps to asking about the involact ~ race model developed in the example text. This feels like it'll make students strip gears a little. Suggest modifying it to have students make a prediction about a penguin -- perhaps: "Use the equation of the regression line to predict the flipper length of a penguin that weighs 4200 grams."
- Relatedly: in 16(k), it's unclear whether we're asking about $R^2$ out of the `involact_race_glance` or out of the `fl_bm_glance` output. I suspect you were thinking about `fl_bm_glance` here because the example has a sentence that comes out of the `involact_race_glance` output. We could clarify this prompt, though.