### PR TITLE
Remove success/failure condition from 12. Confidence intervals

### DIFF
--- a/12-confidence_intervals-web.Rmd
+++ b/12-confidence_intervals-web.Rmd
@@ -372,9 +372,6 @@ Use the `smoking` data set from the `openintro` package. What percentage of the 
 - 10%
     - [Check condition here.]
     
-- Success/failure
-    - [Check condition here.]
-    
 :::
 
 ###### Calculate and graph the confidence interval. {-}

--- a/docs/chapter_downloads/12-confidence_intervals.Rmd
+++ b/docs/chapter_downloads/12-confidence_intervals.Rmd
@@ -379,9 +379,6 @@ Use the `smoking` data set from the `openintro` package. What percentage of the 
 - 10%
     - [Check condition here.]
     
-- Success/failure
-    - [Check condition here.]
-    
 :::
 
 ###### Calculate and graph the confidence interval.


### PR DESCRIPTION
If this is mathematically incorrect, please feel free to revoke this commit, but:

Since we're bootstrapping the confidence intervals in this new approach, and therefore no longer using the normal model, I'm *pretty* sure we don't need to check the success/failure condition. If I understand it right, that's a condition for using the normal model, and the bootstrap doesn't require it.