### PR TITLE
`library(openintro)` was accidentally omitted from 17

### DIFF
--- a/17-chi_square_goodness_of_fit-web.Rmd
+++ b/17-chi_square_goodness_of_fit-web.Rmd
@@ -44,6 +44,7 @@ We load the standard `tidyverse`, `janitor`, and `infer` packages and the `openi
 library(tidyverse)
 library(janitor)
 library(infer)
+library(openintro)
 ```
 
 

--- a/docs/chapter_downloads/17-chi_square_goodness_of_fit.Rmd
+++ b/docs/chapter_downloads/17-chi_square_goodness_of_fit.Rmd
@@ -52,6 +52,7 @@ We load the standard `tidyverse`, `janitor`, and `infer` packages and the `openi
 library(tidyverse)
 library(janitor)
 library(infer)
+library(openintro)
 ```
 
 


### PR DESCRIPTION
R module 17 uses the `hsb2` dataset from `openintro` for the "Your turn" part, but `library(openintro)` accidentally didn't make it into the library-loading code chunk.