### PR TITLE
Lingering text from posthoc lead-in

### DIFF
--- a/22-anova-web.Rmd
+++ b/22-anova-web.Rmd
@@ -481,7 +481,7 @@ Please write up your answer here.
 *****
 
 
-There is no confidence interval for ANOVA. We are not hypothesizing about the value of any particular parameter, so there's nothing to estimate with a confidence interval. However, there is something of interest to estimate. That leads us to the...
+There is no confidence interval for ANOVA. We are not hypothesizing about the value of any particular parameter, so there's nothing to estimate with a confidence interval.
 
 
 ## Your turn

--- a/docs/chapter_downloads/22-anova.Rmd
+++ b/docs/chapter_downloads/22-anova.Rmd
@@ -489,7 +489,7 @@ Please write up your answer here.
 *****
 
 
-There is no confidence interval for ANOVA. We are not hypothesizing about the value of any particular parameter, so there's nothing to estimate with a confidence interval. However, there is something of interest to estimate. That leads us to the...
+There is no confidence interval for ANOVA. We are not hypothesizing about the value of any particular parameter, so there's nothing to estimate with a confidence interval.
 
 
 ## Your turn


### PR DESCRIPTION
Current version of 22-anova.rmd has some text that looks like it used to be for leading students into a post-hoc analysis section. Unfortunately that doesn't exist because of `infer` so I removed a sentence or two.